### PR TITLE
fix bug in autoscale in add_track_interaction.sh

### DIFF
--- a/GIVE-Toolbox/add_track_interaction.sh
+++ b/GIVE-Toolbox/add_track_interaction.sh
@@ -13,7 +13,7 @@ usage() {
     -s <short_label>: (Required) The label that will be shown in the label region.
     -o <priority>: (Required) The order of the track in the browser. Smaller value means the the track will be shown in a higher location.
     -v <visibility>: (Required) "full" or "none". The display mode of the track. If "full", signals will be plotted against the genome in a line graph. If "none", this track is not shown at all.
-    -q <quantiles>: (Optional) The quantile values used for scaling. If not supplied, it will be in mono color mode. If color gradient based on quantile is desired, an array of quantile values should be provided here. value will be scaled by quantiles before being mapped onto the color gradient. An example: "0.37,1.32,1.78,2.19,2.60,2.97,3.43,3.85,4.34,4.90,5.48,6.16,6.94,8.01,9.05,10.41,12.37,14.88,19.84,31.77,290.17" 
+    -q <quantiles>: (Optional) The quantile values used for scaling. If not supplied, it will be in mono color autoscale mode. If color gradient based on quantile is desired, an array of quantile values should be provided here. Value will be scaled by quantiles before being mapped onto the color gradient. The quantile value used in the GIVE-Toolbox example: -q "0.37,1.32,1.78,2.19,2.60,2.97,3.43,3.85,4.34,4.90,5.48,6.16,6.94,8.01,9.05,10.41,12.37,14.88,19.84,31.77,290.17" 
     -f <file>: (Required) interaction file path. It must be a system absolute path. Make sure MySQL can access this file.
     -h : show usage help
 EOF
@@ -47,7 +47,7 @@ done
 [  -z "$short_label" ] && echo "Error: -s <short_label> is empty" && usage && exit 1 
 [  -z "$priority" ] && echo "Error: -o <priority> is empty" && usage && exit 1 
 [  -z "$visibility" ] && echo "Error: -v <visibility> is empty" && usage && exit 1 
-[  -z "$quantiles" ] && echo "Error: -a <autoscale> is empty" && usage && exit 1 
+[  -z "$quantiles" ] && quantiles="autoscale"
 [  -z "$file" ] && echo "Error: -f <file> is empty" && usage && exit 1 
 
 read -r -d '' mysql_query <<EOF

--- a/GIVE-Toolbox/add_track_interaction.sh
+++ b/GIVE-Toolbox/add_track_interaction.sh
@@ -3,7 +3,7 @@ PROGNAME=$0
 
 usage() {
     cat << EOF >&2
-    Usage: $PROGNAME [-u <mysqlu>] [-p <mysqlp>] [-r <ref>] [-t <track_name>] [-g <group_name>] [-l <long_label>] [-s <short_label>] [-o <priority>] [-v <visibility>] [-q <quantile>] [-f <file>]
+    Usage: $PROGNAME [-u <mysqlu>] [-p <mysqlp>] [-r <ref>] [-t <track_name>] [-g <group_name>] [-l <long_label>] [-s <short_label>] [-o <priority>] [-v <visibility>] [-q <quantiles>] [-f <file>]
     -u <mysqlu>: (Required) MySQL account name
     -p <mysqlp>: (Optional) MySQL account passwd. Without '-p', the promot will ask you to input password.
     -r <ref>: (Required) ref genome database name. The ref genome database must has been initialized. If not, please use initial_ref.sh to do it. 

--- a/manuals/3.1-GIVE-Toolbox-usages.md
+++ b/manuals/3.1-GIVE-Toolbox-usages.md
@@ -123,8 +123,9 @@ bash add_track_interaction.sh [-u <mysqlu>] [-p <mysqlp>] [-r <ref>] [-t <track_
 - `-s <short_label>`: (required) The label that will be shown in the label region.
 - `-o <priority>`: (required) The order of the track in the browser. Smaller value means the the track will be shown in a higher location.
 - `-v <visibility>`: (required) "full" or "none". The display mode of the track. If "full", signals will be plotted against the genome in a line graph. If "none", this track is not shown at all.
-- `-q <quantiles>`: (optional) The quantile values used for scaling. If color gradient based on quantile instead of absolute values is desired, an array of quantile values should be provided here. value will be scaled by quantiles before being mapped onto the color gradient. An example: "0.37,1.32,1.78,2.19,2.60,2.97,3.43,3.85,4.34,4.90,5.48,6.16,6.94,8.01,9.05,10.41,12.37,14.88,19.84,31.77,290.17"
+- `-q <quantiles>`: (Optional) The quantile values used for scaling. If not supplied, it will be in mono color autoscale mode. If color gradient based on quantile is desired, an array of quantile values should be provided here. Value will be scaled by quantiles before being mapped onto the color gradient. The quantile value used in the GIVE-Toolbox example: -q "0.37,1.32,1.78,2.19,2.60,2.97,3.43,3.85,4.34,4.90,5.48,6.16,6.94,8.01,9.05,10.41,12.37,14.88,19.84,31.77,290.17" 
 - `-f <file>`: (required) Interaction file path. It must be a system absolute path. Make sure MySQL can access this file.
+- `-h`: show usage help
 
 ### 7. `config_host.sh`
 This script tool will configure the "<give_root>/includes/constants.php" and "<give_root>/html/components/basic-func/constants.js" with user supplied arguments. Please make sure that you have the authority to write these files.


### PR DESCRIPTION
In the previous version, -q must be set as "autoscale" for autoscale the quantile.
In the updated version, autoscale will be the default setting when -q is ignored.

